### PR TITLE
Improve LD score memory management

### DIFF
--- a/ld.py
+++ b/ld.py
@@ -10,6 +10,8 @@ from typing import Optional, Tuple
 import numpy as np
 import pandas as pd
 import time
+import os
+import tempfile
 
 from util.bim import (read_bim_file, BIM_COLUMNS, BIM_CHR_COL, BIM_RSID_COL, BIM_CM_COL,
                       BIM_BP_COL, BIM_A1_COL, BIM_A2_COL, BIM_SEPARATOR)
@@ -44,6 +46,14 @@ MERGED_MATCHED_FILTER_NAME = "merged_matched_alleles"
 MERGED_SWAPPED_FILTER_NAME = "merged_swapped_alleles"
 MERGED_BIM_FILTERS = {MERGED_MATCHED_FILTER_NAME : merged_matched_alleles,
                       MERGED_SWAPPED_FILTER_NAME : merged_swapped_alleles}
+
+
+def _create_memmap(shape, dtype=np.float32):
+    """Create a temporary memmap-backed array."""
+    tmp = tempfile.NamedTemporaryFile(delete=False)
+    path = tmp.name
+    tmp.close()
+    return np.memmap(path, dtype=dtype, mode="w+", shape=shape), path
 
 
 def get_population_indices(df1: pd.DataFrame, df2: pd.DataFrame = None):
@@ -170,7 +180,9 @@ def calculate_R_without_nan(G, lower_extents, step_size=100, mmap_prefix='./'):
 
 # Assumes matrices are filtered to common SNPs before being passed in
 def calculate_ld_scores(banded_r: Tuple[np.ndarray], N: float = 3.0,
-                        lower_extents: np.ndarray = None, swaps: np.ndarray=None):
+                        lower_extents: np.ndarray = None, swaps: np.ndarray=None,
+                        use_memmap: bool = False):
+    """Calculate LD scores using optionally memmap-backed temporary arrays."""
 
     # Input parameter checking plus creating some aliases for readability
     one_anc = len(banded_r) == 1
@@ -187,7 +199,17 @@ def calculate_ld_scores(banded_r: Tuple[np.ndarray], N: float = 3.0,
 
     # Start with product of R matrices, divided through by the R diagonal (which is a row here)
     logging.debug("Calculating correlation product / squared correlation...")
-    r_prod = np.multiply(r_1[0:joint_extent], r_2[0:joint_extent])
+    r_prod_path = None
+    if use_memmap:
+        r_prod, r_prod_path = _create_memmap((joint_extent, M))
+        np.multiply(r_1[0:joint_extent], r_2[0:joint_extent], out=r_prod)
+    else:
+        try:
+            r_prod = np.multiply(r_1[0:joint_extent], r_2[0:joint_extent])
+        except MemoryError:
+            logging.info("Insufficient memory for R product, using memmap.")
+            r_prod, r_prod_path = _create_memmap((joint_extent, M))
+            np.multiply(r_1[0:joint_extent], r_2[0:joint_extent], out=r_prod)
     final_divisor = r_prod[0].copy()
 
     # If reference allele alignment needs to be taken into account, do so
@@ -233,7 +255,14 @@ def calculate_ld_scores(banded_r: Tuple[np.ndarray], N: float = 3.0,
         del diag_element_products
         del correction
 
+    if isinstance(r_prod, np.memmap):
+        r_prod.flush()
     del r_prod
+    if r_prod_path is not None:
+        try:
+            os.remove(r_prod_path)
+        except OSError:
+            pass
     gc.collect()
 
     # Divide through by the R product diagonal

--- a/pop_info.py
+++ b/pop_info.py
@@ -5,7 +5,8 @@ import numpy as np
 import pandas as pd
 
 from ld import (calculate_R_without_nan, calculate_ld_scores, calculate_lower_extents,
-                get_population_indices, read_bim_file, qc_bim_df, read_and_qc_bim_file)
+                get_population_indices, read_bim_file, qc_bim_df, read_and_qc_bim_file,
+                _create_memmap)
 from util.bed import read_bed_file
 from util.bim import BIM_RSID_COL
 from util.df import run_filters
@@ -163,12 +164,13 @@ class PopInfo:
 
 
     def calc_ldscores(self, other: 'PopInfo', self_mat: np.ndarray=None,
-        other_mat: np.ndarray = None):
+        other_mat: np.ndarray = None, use_memmap: bool = False):
 
         if self.id == other.id:
             r = self.get_banded_R() if self_mat is None else self_mat
             logging.info("Calculating LD scores for population %s", self.id)
-            ldscores = pd.Series(calculate_ld_scores((r,), self.N, self.lower_extents),
+            ldscores = pd.Series(calculate_ld_scores((r,), self.N, self.lower_extents,
+                                                    use_memmap=use_memmap),
                                  index=self.bim_df[BIM_RSID_COL],
                                  name="%s_%s" % (self.id, self.id))
         else:
@@ -180,8 +182,18 @@ class PopInfo:
             c1 = self.cross_indices[other.id]
             c2 = other.cross_indices[self.id]
 
-            r1 = np.zeros((joint_extent, joint_M))
-            r2 = np.zeros((joint_extent, joint_M))
+            r1_path = r2_path = None
+            if use_memmap:
+                r1, r1_path = _create_memmap((joint_extent, joint_M))
+                r2, r2_path = _create_memmap((joint_extent, joint_M))
+            else:
+                try:
+                    r1 = np.zeros((joint_extent, joint_M))
+                    r2 = np.zeros((joint_extent, joint_M))
+                except MemoryError:
+                    logging.info("Insufficient memory for LD score matrices, using memmap.")
+                    r1, r1_path = _create_memmap((joint_extent, joint_M))
+                    r2, r2_path = _create_memmap((joint_extent, joint_M))
 
             b1 = np.full(self.M, False)
             b1[c1] = True
@@ -213,7 +225,21 @@ class PopInfo:
                          self.id, other.id)
             ldscores = pd.Series(calculate_ld_scores((r1[0:joint_extent_after_processing],
                                                       r2[0:joint_extent_after_processing]),
-                                                     swaps=swap_mask[self.cross_indices[other.id]]),
+                                                     swaps=swap_mask[self.cross_indices[other.id]],
+                                                     use_memmap=use_memmap),
                                  index=self.bim_df[BIM_RSID_COL].iloc[self.cross_indices[other.id]],
                                  name=f"{self.id}_{other.id}")
+
+            if isinstance(r1, np.memmap):
+                r1.flush()
+            if isinstance(r2, np.memmap):
+                r2.flush()
+            del r1
+            del r2
+            for path in (r1_path, r2_path):
+                if path is not None:
+                    try:
+                        os.remove(path)
+                    except OSError:
+                        pass
         return ldscores

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ bitarray>=2.9
 numpy>=1.26
 pandas>=2.2
 scipy>=1.12
+pytest>=7


### PR DESCRIPTION
## Summary
- support optional memmap usage in `calculate_ld_scores`
- import helper from `ld` and expose memmap option in `PopInfo.calc_ldscores`
- clean up temporary memmap files after use
- ensure temporary files are closed before use
- include `pytest` dependency

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*